### PR TITLE
Improve diagnostics for missing instances

### DIFF
--- a/compiler/src/compile/typecheck/mod.rs
+++ b/compiler/src/compile/typecheck/mod.rs
@@ -5,7 +5,7 @@ mod format;
 mod traverse;
 
 pub use engine::{BuiltinType, Type};
-pub use format::format_type;
+pub use format::{format_type, FormattableType};
 
 use crate::{
     compile::lower, diagnostics::*, helpers::InternedString, parse::Span, Compiler, FilePath,
@@ -792,8 +792,8 @@ impl<L> Compiler<L> {
             }
 
             let type_names = getter!(types);
-            let param_names = getter!(type_parameters);
             let trait_names = getter!(traits);
+            let param_names = getter!(type_parameters);
 
             #[allow(unused_mut)]
             let mut diagnostic = match error.error {
@@ -811,19 +811,23 @@ impl<L> Compiler<L> {
                         error.span,
                         format!(
                             "expected `{}`, but found `{}`",
-                            format_type(expected, type_names, param_names),
-                            format_type(actual, type_names, param_names)
+                            format_type(expected, type_names, trait_names, param_names),
+                            format_type(actual, type_names, trait_names, param_names)
                         ),
                     )],
                 ),
-                TypeError::MissingInstance(tr, ty) => Diagnostic::error(
+                TypeError::MissingInstance(tr, params) => Diagnostic::error(
                     "missing instance",
                     vec![Note::primary(
                         error.span,
                         format!(
-                            "could not find instance of `{}` for type `{}`",
-                            trait_names(tr),
-                            format_type(ty, type_names, param_names)
+                            "could not find instance `{}`",
+                            format_type(
+                                FormattableType::Trait(tr, params),
+                                type_names,
+                                trait_names,
+                                param_names
+                            )
                         ),
                     )],
                 ),
@@ -2250,6 +2254,10 @@ impl<'a, L> Typechecker<'a, L> {
     ) -> Result<GenericConstantId, TypeError> {
         ty.apply(&self.ctx);
 
+        let tr_decl = self.traits.get(&tr).unwrap().clone();
+        let mut temp_ctx = self.ctx.clone();
+        temp_ctx.unify(ty.clone(), tr_decl.ty.clone())?;
+
         macro_rules! find_instance {
             ($instances:expr, $unify:ident, $transform:expr,) => {{
                 let instances = $instances;
@@ -2304,7 +2312,15 @@ impl<'a, L> Typechecker<'a, L> {
             },
         );
 
-        Err(TypeError::MissingInstance(tr, ty))
+        let params = self.ctx.unify_params(ty, tr_decl.ty.clone()).0;
+
+        let params = tr_decl
+            .params
+            .into_iter()
+            .map(|param| params.get(&param).unwrap().clone())
+            .collect();
+
+        Err(TypeError::MissingInstance(tr, params))
     }
 
     fn convert_type_annotation(

--- a/test/tests/missing-instance.yml
+++ b/test/tests/missing-instance.yml
@@ -10,9 +10,9 @@ diagnostics: |
        --> prelude:107:17
         |
     107 | show :: A where (Show A) => A -> ()
-        |                 ^^^^^^^^ could not find instance of `Show` for type `Foo -> Text`
+        |                 ^^^^^^^^ could not find instance `Show Foo`
     error: missing instance
        --> test:3:1
         |
     3   | show Foo
-        | ^^^^ could not find instance of `Show` for type `Foo -> Text`
+        | ^^^^ could not find instance `Show Foo`


### PR DESCRIPTION
For example, there is no instance for `T Y` in this program:

```wipple
T : A => trait A

X : type
instance T X : X

Y : type

(T :: Y)
```

Before, the error message would read "could not find instance of `T` for type `Y`". Now, it reads "could not find instance `T Y`", matching the syntax for instances.