### PR TITLE
Implement C FFI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,6 +823,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +856,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "975de676448231fcde04b9149d2543077e166b78fc29eae5aa219e7928410da2"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2037,6 +2053,7 @@ dependencies = [
 name = "wipple-rust-backend"
 version = "0.0.0"
 dependencies = [
+ "nom",
  "proc-macro2",
  "quote",
  "syn",

--- a/backends/interpreter/src/lib.rs
+++ b/backends/interpreter/src/lib.rs
@@ -126,9 +126,9 @@ impl<'a> Interpreter<'a> {
 
                                 self.call(function, input, info, &mut (**captures).clone())?
                             }
-                            ir::ExpressionKind::External(abi, identifier, inputs) => {
-                                if abi.as_str() != ir::abi::RUNTIME {
-                                    return Err(Error::from("unknown ABI (only 'runtime' is supported in the interpreter)"));
+                            ir::ExpressionKind::External(lib, identifier, inputs) => {
+                                if lib.as_str() != ir::lib::RUNTIME {
+                                    return Err(Error::from("unknown external library (only 'runtime' is supported in the interpreter)"));
                                 }
 
                                 self.call_runtime(

--- a/backends/rust/Cargo.toml
+++ b/backends/rust/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
+nom = "7"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "1", features = ["full"] }

--- a/frontend/src/analysis/ast/mod.rs
+++ b/frontend/src/analysis/ast/mod.rs
@@ -513,14 +513,14 @@ impl<L: Loader> Compiler<L> {
                     self.build_pattern(*input),
                     Box::new(self.build_expression(*body)),
                 ),
-                NodeKind::External(abi, identifier, inputs) => {
-                    let abi = match abi.kind {
+                NodeKind::External(lib, identifier, inputs) => {
+                    let lib = match lib.kind {
                         NodeKind::Error => return ExpressionKind::Error,
                         NodeKind::Text(text) => text,
                         _ => {
                             self.diagnostics.add(Diagnostic::error(
                                 "expected text here",
-                                vec![Note::primary(abi.span, "`external` requires an ABI")],
+                                vec![Note::primary(lib.span, "`external` requires an ABI")],
                             ));
 
                             return ExpressionKind::Error;
@@ -544,7 +544,7 @@ impl<L: Loader> Compiler<L> {
                     };
 
                     ExpressionKind::External(
-                        abi,
+                        lib,
                         identifier,
                         inputs
                             .into_iter()

--- a/frontend/src/analysis/expand/builtins.rs
+++ b/frontend/src/analysis/expand/builtins.rs
@@ -356,6 +356,7 @@ pub(super) fn load_builtins<L: Loader>(expander: &mut Expander<L>, scope: &Scope
 
                 let precedence = match lhs.kind {
                     NodeKind::Name(name) => match name.as_str() {
+                        "cast" => OperatorPrecedence::Cast,
                         "power" => OperatorPrecedence::Power,
                         "multiplication" => OperatorPrecedence::Multiplication,
                         "addition" => OperatorPrecedence::Addition,
@@ -553,13 +554,13 @@ pub(super) fn load_builtins<L: Loader>(expander: &mut Expander<L>, scope: &Scope
 
                     let mut inputs = VecDeque::from(inputs);
 
-                    let abi = inputs.pop_front().unwrap();
+                    let lib = inputs.pop_front().unwrap();
                     let identifier = inputs.pop_front().unwrap();
                     let inputs = Vec::from(inputs);
 
                     Node {
                         span,
-                        kind: NodeKind::External(Box::new(abi), Box::new(identifier), inputs),
+                        kind: NodeKind::External(Box::new(lib), Box::new(identifier), inputs),
                     }
                 })
             }),

--- a/frontend/src/analysis/expand/mod.rs
+++ b/frontend/src/analysis/expand/mod.rs
@@ -371,6 +371,7 @@ pub struct Operator {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub enum OperatorPrecedence {
+    Cast,
     Power,
     Multiplication,
     Addition,
@@ -396,6 +397,7 @@ pub enum OperatorAssociativity {
 impl OperatorPrecedence {
     pub fn associativity(&self) -> OperatorAssociativity {
         match self {
+            OperatorPrecedence::Cast => OperatorAssociativity::Left,
             OperatorPrecedence::Conjunction => OperatorAssociativity::Left,
             OperatorPrecedence::Disjunction => OperatorAssociativity::Left,
             OperatorPrecedence::Comparison => OperatorAssociativity::Left,
@@ -1161,8 +1163,8 @@ impl<L: Loader> Expander<L> {
                             replace(lhs, map);
                             replace(rhs, map);
                         }
-                        NodeKind::External(abi, identifier, inputs) => {
-                            replace(abi, map);
+                        NodeKind::External(lib, identifier, inputs) => {
+                            replace(lib, map);
                             replace(identifier, map);
 
                             for input in inputs {

--- a/frontend/src/analysis/lower/builtins.rs
+++ b/frontend/src/analysis/lower/builtins.rs
@@ -59,8 +59,23 @@ impl<L: Loader> Compiler<L> {
                 kind: BuiltinTypeKind::Number,
                 attributes: DeclarationAttributes {
                     help: vec![InternedString::new(
-                        "Represents a number. Unlike in most languages, Wipple numbers are stored in decimal format instead of floating-point format, making calculations with base-10 numbers more accurate.",
+                        "Represents a whole or fractional number, represented as a 64-bit floating point value. By default, numeric literals have the type `Number`; if you need to convert it to an `Integer`, use the `as?` operator.",
                     )],
+                    ..Default::default()
+                }
+            },
+        );
+
+        add!(
+            builtin_types,
+            Span::builtin("`Integer` type"),
+            "Integer",
+            INTEGER_TYPE: BuiltinTypeId = self.new_builtin_type_id(),
+            ScopeValue::BuiltinType,
+            BuiltinType {
+                kind: BuiltinTypeKind::Integer,
+                attributes: DeclarationAttributes {
+                    help: vec![InternedString::new("Represents a whole number, specifically a 64-bit signed integer. Integers are most commonly used when dealing with lists, whose items can only be accessed at whole-number intervals.",)],
                     ..Default::default()
                 }
             },

--- a/frontend/src/analysis/lower/mod.rs
+++ b/frontend/src/analysis/lower/mod.rs
@@ -91,6 +91,7 @@ pub struct BuiltinType {
 pub enum BuiltinTypeKind {
     Never,
     Number,
+    Integer,
     Boolean,
     Text,
     List,
@@ -1350,8 +1351,8 @@ impl<L: Loader> Compiler<L> {
                     })
                     .collect(),
             ),
-            ast::ExpressionKind::External(abi, identifier, inputs) => ExpressionKind::External(
-                abi,
+            ast::ExpressionKind::External(lib, identifier, inputs) => ExpressionKind::External(
+                lib,
                 identifier,
                 inputs
                     .into_iter()

--- a/frontend/src/analysis/typecheck/engine.rs
+++ b/frontend/src/analysis/typecheck/engine.rs
@@ -50,6 +50,7 @@ impl From<Type> for UnresolvedType {
             }
             Type::Builtin(builtin) => UnresolvedType::Builtin(match builtin {
                 BuiltinType::Number => BuiltinType::Number,
+                BuiltinType::Integer => BuiltinType::Integer,
                 BuiltinType::Text => BuiltinType::Text,
                 BuiltinType::List(ty) => BuiltinType::List(Box::new((*ty).into())),
                 BuiltinType::Mutable(ty) => BuiltinType::Mutable(Box::new((*ty).into())),
@@ -83,6 +84,7 @@ pub struct TypeVariable(pub usize);
 #[serde(tag = "type", content = "value")]
 pub enum BuiltinType<Ty> {
     Number,
+    Integer,
     Text,
     List(Ty),
     Mutable(Ty),
@@ -303,6 +305,7 @@ impl Context {
                 UnresolvedType::Builtin(expected_builtin),
             ) => match (actual_builtin, expected_builtin) {
                 (BuiltinType::Number, BuiltinType::Number) => Ok(()),
+                (BuiltinType::Integer, BuiltinType::Integer) => Ok(()),
                 (BuiltinType::Text, BuiltinType::Text) => Ok(()),
                 (BuiltinType::List(actual_element), BuiltinType::List(expected_element))
                 | (BuiltinType::Mutable(actual_element), BuiltinType::Mutable(expected_element)) => {
@@ -497,6 +500,7 @@ impl UnresolvedType {
             ),
             UnresolvedType::Builtin(builtin) => Type::Builtin(match builtin {
                 BuiltinType::Number => BuiltinType::Number,
+                BuiltinType::Integer => BuiltinType::Integer,
                 BuiltinType::Text => BuiltinType::Text,
                 BuiltinType::List(ty) => BuiltinType::List(Box::new(ty.finalize(ctx, generic)?)),
                 BuiltinType::Mutable(ty) => {

--- a/frontend/src/analysis/typecheck/format.rs
+++ b/frontend/src/analysis/typecheck/format.rs
@@ -107,6 +107,7 @@ fn format_type_with(
             FormattableType::Type(UnresolvedType::Builtin(ty)) => (
                 match ty {
                     BuiltinType::Number => format_named_type!("Number", Vec::new()),
+                    BuiltinType::Integer => format_named_type!("Integer", Vec::new()),
                     BuiltinType::Text => format_named_type!("Text", Vec::new()),
                     BuiltinType::List(ty) => format_named_type!("List", vec![*ty]),
                     BuiltinType::Mutable(ty) => format_named_type!("Mutable", vec![*ty]),

--- a/frontend/src/ir/format.rs
+++ b/frontend/src/ir/format.rs
@@ -96,10 +96,10 @@ impl std::fmt::Display for Program {
                             mangle_computation(*func),
                             mangle_computation(*input)
                         )?,
-                        ExpressionKind::External(abi, identifier, inputs) => writeln!(
+                        ExpressionKind::External(lib, identifier, inputs) => writeln!(
                             f,
                             "external {:?} {:?} {}",
-                            abi,
+                            lib,
                             identifier,
                             inputs
                                 .iter()
@@ -230,6 +230,7 @@ impl std::fmt::Display for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Type::Number => write!(f, "number"),
+            Type::Integer => write!(f, "integer"),
             Type::Text => write!(f, "text"),
             Type::Discriminant => write!(f, "discriminant"),
             Type::Boolean => write!(f, "boolean"),

--- a/frontend/src/ir/mod.rs
+++ b/frontend/src/ir/mod.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use std::{collections::BTreeMap, mem};
 
-pub mod abi {
+pub mod lib {
     pub const RUNTIME: &str = "runtime";
 }
 
@@ -52,6 +52,7 @@ impl<I> Section<I> {
 pub enum Type {
     Number,
     Text,
+    Integer,
     Discriminant,
     Boolean,
     Function(Box<Type>, Box<Type>),
@@ -487,7 +488,7 @@ impl<L: Loader> Compiler<L> {
                             info,
                         );
                     }
-                    typecheck::ExpressionKind::External(abi, identifier, exprs) => {
+                    typecheck::ExpressionKind::External(lib, identifier, exprs) => {
                         let mut inputs = Vec::with_capacity(exprs.len());
                         for expr in exprs {
                             let computation = or_unreachable!(
@@ -501,7 +502,7 @@ impl<L: Loader> Compiler<L> {
                             computation,
                             Expression {
                                 ty,
-                                kind: ExpressionKind::External(*abi, *identifier, inputs),
+                                kind: ExpressionKind::External(*lib, *identifier, inputs),
                             },
                         ));
                     }
@@ -761,7 +762,7 @@ impl<L: Loader> Compiler<L> {
                     Expression {
                         ty: Type::Boolean,
                         kind: ExpressionKind::External(
-                            InternedString::new(abi::RUNTIME),
+                            InternedString::new(lib::RUNTIME),
                             InternedString::new("number-equality"),
                             vec![input, predicate],
                         ),
@@ -791,7 +792,7 @@ impl<L: Loader> Compiler<L> {
                     Expression {
                         ty: Type::Boolean,
                         kind: ExpressionKind::External(
-                            InternedString::new(abi::RUNTIME),
+                            InternedString::new(lib::RUNTIME),
                             InternedString::new("text-equality"),
                             vec![input, predicate],
                         ),
@@ -1064,6 +1065,7 @@ impl<L: Loader> Compiler<L> {
             typecheck::Type::Builtin(ty) => match ty {
                 typecheck::BuiltinType::Number => Type::Number,
                 typecheck::BuiltinType::Text => Type::Text,
+                typecheck::BuiltinType::Integer => Type::Integer,
                 typecheck::BuiltinType::List(ty) => Type::List(Box::new(self.gen_type(*ty, info))),
                 typecheck::BuiltinType::Mutable(ty) => {
                     Type::Mutable(Box::new(self.gen_type(*ty, info)))
@@ -1152,8 +1154,8 @@ impl Expression<UnresolvedSectionIndex> {
                 ExpressionKind::Number(number) => ExpressionKind::Number(number),
                 ExpressionKind::Text(text) => ExpressionKind::Text(text),
                 ExpressionKind::Call(function, input) => ExpressionKind::Call(function, input),
-                ExpressionKind::External(abi, identifier, inputs) => {
-                    ExpressionKind::External(abi, identifier, inputs)
+                ExpressionKind::External(lib, identifier, inputs) => {
+                    ExpressionKind::External(lib, identifier, inputs)
                 }
                 ExpressionKind::Tuple(values) => ExpressionKind::Tuple(values),
                 ExpressionKind::Structure(values) => ExpressionKind::Structure(values),

--- a/pkg/std/util.wpl
+++ b/pkg/std/util.wpl
@@ -11,12 +11,6 @@ crash : message -> external "runtime" "crash" message
 ... :: !
 ... : crash "not yet implemented"
 
-[help "Represents the default or initial value of a type."]
-Default : A => trait A
-instance Default Number : 0
-instance Default Text : ""
-instance Default Boolean : False
-
 [help "Represents the presence or absence of a value."]
 Maybe : Value => type {
 	None
@@ -79,3 +73,26 @@ unwrap :: Container Value
 	where (Expect Container Value) (Unwrap-Message Container) =>
 	Container -> Value
 unwrap : x? -> expect (Unwrap-Message x?) x?
+
+
+As : Input Output => trait (Input -> Output)
+
+as : cast operator (x t ~> (As x :: t))
+
+A => instance As A A : it
+instance As Integer Number : n -> external "runtime" "integer-to-number" n
+
+As? : Input Output => trait (Input -> Maybe Output)
+
+as? : cast operator (x t ~> (As? x :: Maybe t))
+
+A => instance As? A A : Some
+instance As? Number Integer : n -> external "runtime" "number-to-integer" n
+
+[help "Represents the default or initial value of a type."]
+Default : A => trait A
+instance Default Number : 0
+instance Default Integer : 0 as? Integer . unwrap
+instance Default Text : ""
+instance Default Boolean : False
+A => instance Default (Maybe A) : None

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -175,6 +175,10 @@ async fn run() -> anyhow::Result<()> {
 
             match backend {
                 RunBackend::Interpreter => {
+                    if let Some(progress_bar) = progress_bar.as_ref() {
+                        progress_bar.finish_and_clear();
+                    }
+
                     let interpreter =
                         wipple_interpreter_backend::Interpreter::handling_output(|text| {
                             print!("{}", text);
@@ -288,8 +292,8 @@ async fn run() -> anyhow::Result<()> {
                     progress_bar.set_message("Compiling to Rust");
                 }
 
-                let tt = wipple_rust_backend::compile(&ir)?;
-                let src = prettyplease::unparse(&syn::parse_file(&tt.to_string()).unwrap());
+                let tokens = wipple_rust_backend::compile(&ir)?;
+                let src = prettyplease::unparse(&syn::parse_file(&tokens.to_string()).unwrap());
 
                 if let Some(progress_bar) = progress_bar.as_ref() {
                     progress_bar.finish_and_clear();
@@ -552,8 +556,8 @@ fn compile_rust(
         progress_bar.set_message("Compiling to Rust");
     }
 
-    let tt = wipple_rust_backend::compile(&ir)?;
-    let src = prettyplease::unparse(&syn::parse_file(&tt.to_string()).unwrap());
+    let tokens = wipple_rust_backend::compile(&ir)?;
+    let src = prettyplease::unparse(&syn::parse_file(&tokens.to_string()).unwrap());
 
     let rustc = match which::which("rustc") {
         Ok(path) => path,


### PR DESCRIPTION
You can now interface with C like so:

```wipple
foo :: Number -> Number
foo : x -> external "lib" "double foo(double)" x
```

This branch also adds back the `Integer` type, which can be cast to C's `int` type:

```wipple
num : 42
int : num as? Integer . unwrap
```