### PR TITLE
Add `[help-show-code]` attribute

### DIFF
--- a/frontend/src/analysis/lower/mod.rs
+++ b/frontend/src/analysis/lower/mod.rs
@@ -178,6 +178,7 @@ pub struct DeclarationAttributes {
     pub help: Vec<InternedString>,
     pub help_group: Option<InternedString>,
     pub help_playground: Option<InternedString>,
+    pub help_show_code: bool,
     pub help_template: Option<InternedString>,
     pub private: bool,
 }
@@ -4621,6 +4622,7 @@ impl Lowerer {
                 .help_playground
                 .as_ref()
                 .map(|attribute| attribute.help_playground_text),
+            help_show_code: statement_attributes.help_show_code.is_some(),
             help_template: statement_attributes
                 .help_template
                 .as_ref()

--- a/frontend/src/analysis/mod.rs
+++ b/frontend/src/analysis/mod.rs
@@ -9,7 +9,7 @@ pub mod typecheck;
 pub use span::{Span, SpanList};
 pub use typecheck::{
     Arm, Bound, Expression, ExpressionKind, Intrinsic, LiteralKind, Pattern, PatternKind, Program,
-    Semantics, Type, TypeAnnotation, TypeAnnotationKind, TypeStructure,
+    Semantics, Type, TypeAnnotation, TypeAnnotationKind, TypeKind, TypeStructure,
 };
 pub use wipple_syntax::{ast, parse};
 

--- a/frontend/src/analysis/mod.rs
+++ b/frontend/src/analysis/mod.rs
@@ -662,4 +662,9 @@ impl Compiler {
                 .to_string(),
         )
     }
+
+    fn single_line_source_code_for_span(&self, span: Span) -> Option<String> {
+        self.source_code_for_span(span)
+            .filter(|code| !code.contains('\n'))
+    }
 }

--- a/frontend/src/analysis/optimize/mod.rs
+++ b/frontend/src/analysis/optimize/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    analysis::{Arm, Expression, ExpressionKind, Pattern, PatternKind, Program, Semantics, Type},
+    analysis::{Arm, Expression, ExpressionKind, Pattern, PatternKind, Program, Semantics},
     Compiler, ItemId, Optimize, VariableId,
 };
 use parking_lot::RwLock;
@@ -64,7 +64,10 @@ impl Optimize for Program {
 
 pub mod ssa {
     use super::*;
-    use crate::{analysis::SpanList, ConstantId};
+    use crate::{
+        analysis::{SpanList, TypeKind},
+        ConstantId,
+    };
 
     #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
     pub struct Options {}
@@ -106,7 +109,8 @@ pub mod ssa {
                                                             .last()
                                                             .map(|expr| expr.ty.clone())
                                                             .unwrap_or_else(|| {
-                                                                Type::Tuple(Vec::new())
+                                                                TypeKind::Tuple(Vec::new())
+                                                                    .with_span(expr.span)
                                                             }),
                                                         span,
                                                         kind: ExpressionKind::Block(

--- a/frontend/src/analysis/typecheck/display.rs
+++ b/frontend/src/analysis/typecheck/display.rs
@@ -1,9 +1,8 @@
-use crate::FieldIndex;
-
 use super::{
     Arm, Expression, ExpressionKind, Pattern, PatternKind, Program, Type, TypeAnnotation,
-    TypeAnnotationKind, TypeDeclKind, TypeStructure,
+    TypeAnnotationKind, TypeDeclKind, TypeKind, TypeStructure,
 };
+use crate::FieldIndex;
 use std::fmt;
 
 impl fmt::Display for Program {
@@ -76,8 +75,8 @@ impl Expression {
         match &self.kind {
             ExpressionKind::Error(_) => write!(f, "<error expression>")?,
             ExpressionKind::Marker => {
-                let id = match self.ty {
-                    Type::Named(id, _, _) => id,
+                let id = match self.ty.kind {
+                    TypeKind::Named(id, _, _) => id,
                     _ => {
                         write!(f, "<unknown marker type>")?;
                         return Ok(());
@@ -165,8 +164,8 @@ impl Expression {
                 write!(f, ")")?;
             }
             ExpressionKind::Function(pattern, value, _) => {
-                let input_ty = match &self.ty {
-                    Type::Function(input, _) => input,
+                let input_ty = match &self.ty.kind {
+                    TypeKind::Function(input, _) => input,
                     _ => {
                         write!(f, "<unknown function>")?;
                         return Ok(());
@@ -215,8 +214,8 @@ impl Expression {
                 value.display_with(f, file, indent)?;
             }
             ExpressionKind::Structure(fields) => {
-                let id = match self.ty {
-                    Type::Named(id, _, _) => id,
+                let id = match self.ty.kind {
+                    TypeKind::Named(id, _, _) => id,
                     _ => {
                         write!(f, "<unknown structure type>")?;
                         return Ok(());
@@ -256,8 +255,8 @@ impl Expression {
                 write!(f, "{}}})", "\t".repeat(indent))?;
             }
             ExpressionKind::Variant(index, values) => {
-                let id = match self.ty {
-                    Type::Named(id, _, _) => id,
+                let id = match self.ty.kind {
+                    TypeKind::Named(id, _, _) => id,
                     _ => {
                         write!(f, "<unknown enumeration type>")?;
                         return Ok(());
@@ -354,8 +353,8 @@ impl Expression {
                 write!(f, ")")?;
             }
             ExpressionKind::Extend(value, fields) => {
-                let id = match self.ty {
-                    Type::Named(id, _, _) => Some(id),
+                let id = match self.ty.kind {
+                    TypeKind::Named(id, _, _) => Some(id),
                     _ => None,
                 };
 
@@ -445,8 +444,8 @@ impl Pattern {
                 write!(f, "{name}")?;
             }
             PatternKind::Destructure(_, fields) => {
-                let (id, field_tys) = match input_ty {
-                    Type::Named(id, _, TypeStructure::Structure(fields)) => (id, fields),
+                let (id, field_tys) = match &input_ty.kind {
+                    TypeKind::Named(id, _, TypeStructure::Structure(fields)) => (id, fields),
                     _ => {
                         write!(f, "<unknown structure type>")?;
                         return Ok(());
@@ -483,8 +482,8 @@ impl Pattern {
                 write!(f, "{}}}", "\t".repeat(indent))?;
             }
             PatternKind::Variant(id, index, patterns) => {
-                let variant_tys = match input_ty {
-                    Type::Named(_, _, TypeStructure::Enumeration(variants)) => variants,
+                let variant_tys = match &input_ty.kind {
+                    TypeKind::Named(_, _, TypeStructure::Enumeration(variants)) => variants,
                     _ => {
                         write!(f, "<unknown enumeration type>")?;
                         return Ok(());
@@ -531,8 +530,8 @@ impl Pattern {
                 write!(f, ")")?;
             }
             PatternKind::Tuple(patterns) => {
-                let value_tys = match input_ty {
-                    Type::Tuple(tys) => tys,
+                let value_tys = match &input_ty.kind {
+                    TypeKind::Tuple(tys) => tys,
                     _ => {
                         write!(f, "<unknown tuple pattern>")?;
                         return Ok(());

--- a/frontend/src/analysis/typecheck/exhaustiveness.rs
+++ b/frontend/src/analysis/typecheck/exhaustiveness.rs
@@ -86,8 +86,8 @@ impl Typechecker {
                             return ControlFlow::Continue(());
                         }
 
-                        let input_ty = match &expr.ty {
-                            analysis::Type::Function(input, _) => input.as_ref(),
+                        let input_ty = match &expr.ty.kind {
+                            analysis::TypeKind::Function(input, _) => input.as_ref(),
                             _ => unreachable!(),
                         };
 
@@ -292,72 +292,85 @@ impl Typechecker {
                 Pattern::Constructor(Constructor::Structure(*id), patterns)
             }
             analysis::PatternKind::Text(_) => Pattern::Constructor(
-                Constructor::Unbounded(analysis::Type::Builtin(
-                    analysis::typecheck::BuiltinType::Text,
-                )),
+                Constructor::Unbounded(
+                    analysis::TypeKind::Builtin(analysis::typecheck::BuiltinType::Text)
+                        .with_span(None),
+                ),
                 Vec::new(),
             ),
             analysis::PatternKind::Number(_) => Pattern::Constructor(
-                Constructor::Unbounded(analysis::Type::Builtin(
-                    analysis::typecheck::BuiltinType::Number,
-                )),
+                Constructor::Unbounded(
+                    analysis::TypeKind::Builtin(analysis::typecheck::BuiltinType::Number)
+                        .with_span(None),
+                ),
                 Vec::new(),
             ),
             analysis::PatternKind::Integer(_) => Pattern::Constructor(
-                Constructor::Unbounded(analysis::Type::Builtin(
-                    analysis::typecheck::BuiltinType::Integer,
-                )),
+                Constructor::Unbounded(
+                    analysis::TypeKind::Builtin(analysis::typecheck::BuiltinType::Integer)
+                        .with_span(None),
+                ),
                 Vec::new(),
             ),
             analysis::PatternKind::Natural(_) => Pattern::Constructor(
-                Constructor::Unbounded(analysis::Type::Builtin(
-                    analysis::typecheck::BuiltinType::Natural,
-                )),
+                Constructor::Unbounded(
+                    analysis::TypeKind::Builtin(analysis::typecheck::BuiltinType::Natural)
+                        .with_span(None),
+                ),
                 Vec::new(),
             ),
             analysis::PatternKind::Byte(_) => Pattern::Constructor(
-                Constructor::Unbounded(analysis::Type::Builtin(
-                    analysis::typecheck::BuiltinType::Byte,
-                )),
+                Constructor::Unbounded(
+                    analysis::TypeKind::Builtin(analysis::typecheck::BuiltinType::Byte)
+                        .with_span(None),
+                ),
                 Vec::new(),
             ),
             analysis::PatternKind::Signed(_) => Pattern::Constructor(
-                Constructor::Unbounded(analysis::Type::Builtin(
-                    analysis::typecheck::BuiltinType::Signed,
-                )),
+                Constructor::Unbounded(
+                    analysis::TypeKind::Builtin(analysis::typecheck::BuiltinType::Signed)
+                        .with_span(None),
+                ),
                 Vec::new(),
             ),
             analysis::PatternKind::Unsigned(_) => Pattern::Constructor(
-                Constructor::Unbounded(analysis::Type::Builtin(
-                    analysis::typecheck::BuiltinType::Unsigned,
-                )),
+                Constructor::Unbounded(
+                    analysis::TypeKind::Builtin(analysis::typecheck::BuiltinType::Unsigned)
+                        .with_span(None),
+                ),
                 Vec::new(),
             ),
             analysis::PatternKind::Float(_) => Pattern::Constructor(
-                Constructor::Unbounded(analysis::Type::Builtin(
-                    analysis::typecheck::BuiltinType::Float,
-                )),
+                Constructor::Unbounded(
+                    analysis::TypeKind::Builtin(analysis::typecheck::BuiltinType::Float)
+                        .with_span(None),
+                ),
                 Vec::new(),
             ),
             analysis::PatternKind::Double(_) => Pattern::Constructor(
-                Constructor::Unbounded(analysis::Type::Builtin(
-                    analysis::typecheck::BuiltinType::Double,
-                )),
+                Constructor::Unbounded(
+                    analysis::TypeKind::Builtin(analysis::typecheck::BuiltinType::Double)
+                        .with_span(None),
+                ),
                 Vec::new(),
             ),
         }
     }
 
     fn convert_ty(&self, ty: &analysis::Type) -> Type {
-        match ty {
-            analysis::Type::Named(id, _, analysis::TypeStructure::Marker) => Type::Marker(*id),
-            analysis::Type::Named(id, _, analysis::TypeStructure::Enumeration(variants)) => {
+        match &ty.kind {
+            analysis::TypeKind::Named(id, _, analysis::TypeStructure::Marker) => Type::Marker(*id),
+            analysis::TypeKind::Named(id, _, analysis::TypeStructure::Enumeration(variants)) => {
                 Type::Enumeration(*id, variants.clone())
             }
-            analysis::Type::Named(id, _, analysis::TypeStructure::Structure(fields)) => {
+            analysis::TypeKind::Named(id, _, analysis::TypeStructure::Structure(fields)) => {
                 Type::Structure(*id, fields.clone())
             }
-            analysis::Type::Named(_, params, analysis::TypeStructure::Recursive(recursive_id)) => {
+            analysis::TypeKind::Named(
+                _,
+                params,
+                analysis::TypeStructure::Recursive(recursive_id),
+            ) => {
                 let decl = self
                     .declarations
                     .borrow()
@@ -404,7 +417,7 @@ impl Typechecker {
                     analysis::typecheck::TypeDeclKind::Alias(ty) => self.convert_ty(&ty),
                 }
             }
-            analysis::Type::Tuple(tys) => Type::Tuple(tys.clone()),
+            analysis::TypeKind::Tuple(tys) => Type::Tuple(tys.clone()),
             _ => Type::Unmatchable(ty.clone()),
         }
     }

--- a/frontend/src/analysis/typecheck/number.rs
+++ b/frontend/src/analysis/typecheck/number.rs
@@ -4,7 +4,7 @@ macro_rules! parse_number {
         (|| {
             use $crate::analysis::typecheck::engine::{BuiltinType, TypeError};
 
-            let builtin = match $ty {
+            let builtin = match &$ty.kind {
                 $expr_ty::Builtin(builtin) => builtin,
                 _ => return None,
             };

--- a/frontend/src/analysis/typecheck/usage.rs
+++ b/frontend/src/analysis/typecheck/usage.rs
@@ -2,7 +2,7 @@ use crate::{
     analysis::{
         self,
         typecheck::{BuiltinType, Type, Typechecker},
-        SpanList, TypeStructure,
+        SpanList, TypeKind, TypeStructure,
     },
     diagnostics::Note,
     VariableId,
@@ -123,8 +123,8 @@ impl Typechecker {
     }
 
     pub(crate) fn no_reuse_message(&self, ty: &Type) -> Option<String> {
-        match ty {
-            Type::Named(id, _, structure) => {
+        match &ty.kind {
+            TypeKind::Named(id, _, structure) => {
                 if let (ty_name, Some(message)) = self
                     .with_type_decl(*id, |decl| (decl.name, decl.attributes.no_reuse))
                     .unwrap()
@@ -146,7 +146,7 @@ impl Typechecker {
                         .find_map(|ty| self.no_reuse_message(ty)),
                 }
             }
-            Type::Builtin(ty) => match ty {
+            TypeKind::Builtin(ty) => match ty {
                 BuiltinType::List(ty) | BuiltinType::Mutable(ty) => self.no_reuse_message(ty),
                 BuiltinType::Number
                 | BuiltinType::Integer

--- a/frontend/src/ir/ssa.rs
+++ b/frontend/src/ir/ssa.rs
@@ -394,9 +394,9 @@ impl Converter<'_> {
     }
 
     fn convert_type(&mut self, ty: &analysis::Type) -> Type {
-        match ty {
-            analysis::Type::Parameter(_) => panic!("unexpected type parameter"),
-            analysis::Type::Named(id, _, structure) => match structure {
+        match &ty.kind {
+            analysis::TypeKind::Parameter(_) => panic!("unexpected type parameter"),
+            analysis::TypeKind::Named(id, _, structure) => match structure {
                 analysis::TypeStructure::Marker => Type::Marker,
                 analysis::TypeStructure::Structure(tys) => {
                     let structure_id = self.compiler.new_structure_id();
@@ -436,14 +436,14 @@ impl Converter<'_> {
                     }
                 }
             },
-            analysis::Type::Function(input, output) => Type::FunctionReference(
+            analysis::TypeKind::Function(input, output) => Type::FunctionReference(
                 Box::new(self.convert_type(input)),
                 Box::new(self.convert_type(output)),
             ),
-            analysis::Type::Tuple(tys) => {
+            analysis::TypeKind::Tuple(tys) => {
                 Type::Tuple(tys.iter().map(|ty| self.convert_type(ty)).collect())
             }
-            analysis::Type::Builtin(ty) => match ty {
+            analysis::TypeKind::Builtin(ty) => match ty {
                 analysis::typecheck::BuiltinType::Number => Type::Number,
                 analysis::typecheck::BuiltinType::Integer => Type::Integer,
                 analysis::typecheck::BuiltinType::Natural => Type::Natural,
@@ -462,7 +462,7 @@ impl Converter<'_> {
                 analysis::typecheck::BuiltinType::Ui => Type::Ui,
                 analysis::typecheck::BuiltinType::TaskGroup => Type::TaskGroup,
             },
-            analysis::Type::Error => unreachable!(),
+            analysis::TypeKind::Error => unreachable!(),
         }
     }
 }

--- a/std/math.wpl
+++ b/std/math.wpl
@@ -6,6 +6,7 @@ use "logic"
 
 [help "Implements the `+` operator."]
 [help-group "Math"]
+[help-show-code]
 [on-unimplemented "cannot add _ to _" Left Right]
 Add : (Left : Number) (Right : Number) (infer Sum) => trait (Right -> Left -> Sum)
 
@@ -33,6 +34,7 @@ instance (Add Double Double Double) : b a -> semantics "pure" (intrinsic "add-do
 
 [help "Implements the `-` operator."]
 [help-group "Math"]
+[help-show-code]
 [on-unimplemented "cannot subtract _ from _" Right Left]
 Subtract : (Left : Number) (Right : Number) (infer Difference) => trait (Right -> Left -> Difference)
 
@@ -60,6 +62,7 @@ instance (Subtract Double Double Double) : b a -> semantics "pure" (intrinsic "s
 
 [help "Implements the `*` operator."]
 [help-group "Math"]
+[help-show-code]
 [on-unimplemented "cannot multiply _ by _" Left Right]
 Multiply : (Left : Number) (Right : Number) (infer Product) => trait (Right -> Left -> Product)
 
@@ -87,6 +90,7 @@ instance (Multiply Double Double Double) : b a -> semantics "pure" (intrinsic "m
 
 [help "Implements the `/` operator."]
 [help-group "Math"]
+[help-show-code]
 [on-unimplemented "cannot divide _ by _" Left Right]
 Divide : (Left : Number) (Right : Number) (infer Quotient) => trait (Right -> Left -> Quotient)
 
@@ -114,6 +118,7 @@ instance (Divide Double Double Double) : b a -> semantics "pure" (intrinsic "div
 
 [help "Implements the `mod` operator."]
 [help-group "Math"]
+[help-show-code]
 [on-unimplemented "cannot divide _ by _" Left Right]
 Modulo : (Left : Number) (Right : Number) (infer Remainder) => trait (Right -> Left -> Remainder)
 
@@ -141,6 +146,7 @@ instance (Modulo Double Double Double) : b a -> semantics "pure" (intrinsic "mod
 
 [help "Implements the `^` operator."]
 [help-group "Math"]
+[help-show-code]
 [on-unimplemented "cannot raise _ to the power of _" Left Right]
 Power : (Left : Number) (Right : Number) (infer Power) => trait (Right -> Left -> Power)
 

--- a/std/math.wpl
+++ b/std/math.wpl
@@ -6,7 +6,7 @@ use "logic"
 
 [help "Implements the `+` operator."]
 [help-group "Math"]
-[on-unimplemented "cannot add `_` to `_`" Left Right]
+[on-unimplemented "cannot add _ to _" Left Right]
 Add : (Left : Number) (Right : Number) (infer Sum) => trait (Right -> Left -> Sum)
 
 [help "Add two values together, returning the sum."]
@@ -33,7 +33,7 @@ instance (Add Double Double Double) : b a -> semantics "pure" (intrinsic "add-do
 
 [help "Implements the `-` operator."]
 [help-group "Math"]
-[on-unimplemented "cannot subtract `_` from `_`" Right Left]
+[on-unimplemented "cannot subtract _ from _" Right Left]
 Subtract : (Left : Number) (Right : Number) (infer Difference) => trait (Right -> Left -> Difference)
 
 [help "Subtract the right side from the left side, returning the difference."]
@@ -60,7 +60,7 @@ instance (Subtract Double Double Double) : b a -> semantics "pure" (intrinsic "s
 
 [help "Implements the `*` operator."]
 [help-group "Math"]
-[on-unimplemented "cannot multiply `_` by `_`" Left Right]
+[on-unimplemented "cannot multiply _ by _" Left Right]
 Multiply : (Left : Number) (Right : Number) (infer Product) => trait (Right -> Left -> Product)
 
 [help "Multiply two values together, returning the product."]
@@ -87,7 +87,7 @@ instance (Multiply Double Double Double) : b a -> semantics "pure" (intrinsic "m
 
 [help "Implements the `/` operator."]
 [help-group "Math"]
-[on-unimplemented "cannot divide `_` by `_`" Left Right]
+[on-unimplemented "cannot divide _ by _" Left Right]
 Divide : (Left : Number) (Right : Number) (infer Quotient) => trait (Right -> Left -> Quotient)
 
 [help "Divide the left side by the right side, returning the quotient."]
@@ -114,7 +114,7 @@ instance (Divide Double Double Double) : b a -> semantics "pure" (intrinsic "div
 
 [help "Implements the `mod` operator."]
 [help-group "Math"]
-[on-unimplemented "cannot divide `_` by `_`" Left Right]
+[on-unimplemented "cannot divide _ by _" Left Right]
 Modulo : (Left : Number) (Right : Number) (infer Remainder) => trait (Right -> Left -> Remainder)
 
 [help "Divide the left side by the right side, returning the remainder."]
@@ -141,7 +141,7 @@ instance (Modulo Double Double Double) : b a -> semantics "pure" (intrinsic "mod
 
 [help "Implements the `^` operator."]
 [help-group "Math"]
-[on-unimplemented "cannot raise `_` to the power of `_`" Left Right]
+[on-unimplemented "cannot raise _ to the power of _" Left Right]
 Power : (Left : Number) (Right : Number) (infer Power) => trait (Right -> Left -> Power)
 
 [help "Raise the left side to the power of the right side."]

--- a/std/random.wpl
+++ b/std/random.wpl
@@ -7,7 +7,7 @@ use "sequence"
 
 [help "Implements the `random` function."]
 [help-group "Random"]
-[on-unimplemented "cannot produce a random `_` from a `_`" Value Range]
+[on-unimplemented "cannot produce a random _ from a _" Value Range]
 Random : Range (infer Value) => trait (Range -> Value)
 
 random :: Range (infer Value) where (Random Range Value) => Range -> Value

--- a/syntax/src/ast/attributes.rs
+++ b/syntax/src/ast/attributes.rs
@@ -3,13 +3,13 @@ use crate::{
         format::Format, AllowOverlappingInstancesStatementAttribute, ContextualStatementAttribute,
         ConvertFromStatementAttribute, DeriveStatementAttribute, DiagnosticAliasStatementAttribute,
         DiagnosticItemStatementAttribute, EntrypointStatementAttribute,
-        HelpGroupStatementAttribute, HelpPlaygroundStatementAttribute, HelpStatementAttribute,
-        HelpTemplateStatementAttribute, HelpUrlFileAttribute, KeywordStatementAttribute,
-        LanguageItemStatementAttribute, NoImplicitUseFileAttribute, NoReuseStatementAttribute,
-        OnMismatchStatementAttribute, OnUnimplementedStatementAttribute,
-        OperatorPrecedenceStatementAttribute, PrivateStatementAttribute,
-        RecursionLimitFileAttribute, SealedStatementAttribute, SpecializeStatementAttribute,
-        SyntaxError,
+        HelpGroupStatementAttribute, HelpPlaygroundStatementAttribute,
+        HelpShowCodeStatementAttribute, HelpStatementAttribute, HelpTemplateStatementAttribute,
+        HelpUrlFileAttribute, KeywordStatementAttribute, LanguageItemStatementAttribute,
+        NoImplicitUseFileAttribute, NoReuseStatementAttribute, OnMismatchStatementAttribute,
+        OnUnimplementedStatementAttribute, OperatorPrecedenceStatementAttribute,
+        PrivateStatementAttribute, RecursionLimitFileAttribute, SealedStatementAttribute,
+        SpecializeStatementAttribute, SyntaxError,
     },
     parse, Driver,
 };
@@ -75,6 +75,7 @@ pub struct StatementAttributes<D: Driver> {
     pub sealed: Option<SealedStatementAttribute<D>>,
     pub no_reuse: Option<NoReuseStatementAttribute<D>>,
     pub entrypoint: Option<EntrypointStatementAttribute<D>>,
+    pub help_show_code: Option<HelpShowCodeStatementAttribute<D>>,
 }
 
 impl<D: Driver> Default for StatementAttributes<D> {
@@ -101,6 +102,7 @@ impl<D: Driver> Default for StatementAttributes<D> {
             sealed: Default::default(),
             no_reuse: Default::default(),
             entrypoint: Default::default(),
+            help_show_code: Default::default(),
         }
     }
 }

--- a/syntax/src/ast/statement_attribute/help_show_code.rs
+++ b/syntax/src/ast/statement_attribute/help_show_code.rs
@@ -1,0 +1,60 @@
+use crate::{
+    ast::{
+        format::Format,
+        statement_attribute::StatementAttributeSyntaxContext,
+        syntax::{Syntax, SyntaxRule, SyntaxRules},
+        SyntaxError,
+    },
+    Driver,
+};
+
+#[derive(Debug, Clone)]
+pub struct HelpShowCodeStatementAttribute<D: Driver> {
+    pub span: D::Span,
+}
+
+impl<D: Driver> HelpShowCodeStatementAttribute<D> {
+    pub fn span(&self) -> D::Span {
+        self.span
+    }
+}
+
+impl<D: Driver> Format<D> for HelpShowCodeStatementAttribute<D> {
+    fn format(self) -> Result<String, SyntaxError<D>> {
+        unimplemented!("call `StatementAttributes::format` instead")
+    }
+}
+
+pub struct HelpShowCodeStatementAttributeSyntax;
+
+impl<D: Driver> Syntax<D> for HelpShowCodeStatementAttributeSyntax {
+    type Context = StatementAttributeSyntaxContext<D>;
+
+    fn rules() -> SyntaxRules<D, Self> {
+        SyntaxRules::new().with(SyntaxRule::<D, Self>::function(
+            "help-show-code",
+            |context, span, _allow_overlapping_instances_span, exprs, _scope| async move {
+                if !exprs.is_empty() {
+                    context.ast_builder.driver.syntax_error(
+                        span,
+                        "`allow-overlapping-instances` does not accept parameters",
+                    );
+                }
+
+                let attribute = HelpShowCodeStatementAttribute { span };
+
+                context
+                    .statement_attributes
+                    .unwrap()
+                    .lock()
+                    .help_show_code = Some(attribute.clone());
+
+                Ok(attribute.into())
+            },
+        ))
+    }
+}
+
+pub(crate) fn builtin_syntax_definitions() -> Vec<crate::ast::BuiltinSyntaxDefinition> {
+    vec![]
+}

--- a/syntax/src/ast/statement_attribute/mod.rs
+++ b/syntax/src/ast/statement_attribute/mod.rs
@@ -9,6 +9,7 @@ definitions! {
     mod help;
     mod help_group;
     mod help_playground;
+    mod help_show_code;
     mod help_template;
     mod keyword;
     mod language_item;
@@ -47,6 +48,7 @@ syntax_group! {
             Help,
             HelpGroup,
             HelpPlayground,
+            HelpShowCode,
             HelpTemplate,
             Keyword,
             LanguageItem,

--- a/tests/mismatched-call.stderr
+++ b/tests/mismatched-call.stderr
@@ -4,9 +4,9 @@ error: mismatched types
  6 │ accepts-text (1 + 2)
    │               ^^^^^ expected `Text`, but found `Number`
    │
-   ┌─ <dir>/std/math.wpl:16:14
+   ┌─ <dir>/std/math.wpl:17:14
    │
-16 │   'a + 'b -> Add 'b 'a
+17 │   'a + 'b -> Add 'b 'a
    │              --- actual error occurred here
    │
    = for more information, see https://wipple.dev/playground/?lesson=errors/mismatched-types

--- a/tests/operator-without-parentheses.stderr
+++ b/tests/operator-without-parentheses.stderr
@@ -1,16 +1,17 @@
-error: cannot add `()` to `Number`
+error: cannot add `show 1` to `2`
    ┌─ test:1:8
    │
  1 │ show 1 + 2
-   │ ------ ^
-   │ │      │
+   │ ------ ^ - this has type `Number`
+   │ │      │  
    │ │      could not find instance `Add () Number _`
    │ │      `+` consumes all expressions on either side; you may be missing parentheses
+   │ this has type `()`
    │ this is parsed as one single input to `+`
    │
-   ┌─ <dir>/std/math.wpl:16:14
+   ┌─ <dir>/std/math.wpl:17:14
    │
-16 │   'a + 'b -> Add 'b 'a
+17 │   'a + 'b -> Add 'b 'a
    │              --- actual error occurred here
    │
    = for more information, see https://wipple.dev/playground/?lesson=errors/missing-instance
@@ -23,6 +24,7 @@ error: missing instance
    │ │         │
    │ │         could not find instance `Or () Boolean _`
    │ │         `or` consumes all expressions on either side; you may be missing parentheses
+   │ this has type `()`
    │ this is parsed as one single input to `or`
    │
    ┌─ <dir>/std/logic.wpl:54:15
@@ -32,15 +34,18 @@ error: missing instance
    │
    = for more information, see https://wipple.dev/playground/?lesson=errors/missing-instance
 
-error: cannot add `Number` to `Text`
+error: cannot add `1` to `"hi"`
    ┌─ test:3:9
    │
  3 │ show (1 + "hi")
-   │         ^ could not find instance `Add Number Text _`
+   │       - ^ ---- this has type `Text`
+   │       │ │  
+   │       │ could not find instance `Add Number Text _`
+   │       this has type `Number`
    │
-   ┌─ <dir>/std/math.wpl:16:14
+   ┌─ <dir>/std/math.wpl:17:14
    │
-16 │   'a + 'b -> Add 'b 'a
+17 │   'a + 'b -> Add 'b 'a
    │              --- actual error occurred here
    │
    = for more information, see https://wipple.dev/playground/?lesson=errors/missing-instance

--- a/tests/useless-expression.stderr
+++ b/tests/useless-expression.stderr
@@ -12,9 +12,9 @@ warning: this expression doesn't do anything
  2 │ 1 + 2
    │ ^^^^^ did you mean to use the result, eg. `show` it?
    │
-   ┌─ <dir>/std/math.wpl:16:14
+   ┌─ <dir>/std/math.wpl:17:14
    │
-16 │   'a + 'b -> Add 'b 'a
+17 │   'a + 'b -> Add 'b 'a
    │              --- actual warning occurred here
    │
    = for more information, see https://wipple.dev/playground/?lesson=errors/useless-expression

--- a/tools/cli/src/doc/mod.rs
+++ b/tools/cli/src/doc/mod.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use std::{collections::BTreeMap, io};
 use wipple_default_loader::is_relative_to_entrypoint;
-use wipple_frontend::analysis::{Program, Type};
+use wipple_frontend::analysis::{Program, TypeKind};
 
 #[derive(Debug, clap::Parser)]
 pub struct Options {
@@ -131,7 +131,7 @@ pub fn document(
         groups.entry(group).or_default().items.insert(
             decl.name.to_string(),
             HelpItem {
-                kind: if matches!(decl.ty, Type::Function(_, _)) {
+                kind: if matches!(decl.ty.kind, TypeKind::Function(_, _)) {
                     String::from("function")
                 } else {
                     String::from("constant")

--- a/tools/cli/src/lsp/mod.rs
+++ b/tools/cli/src/lsp/mod.rs
@@ -13,7 +13,7 @@ use wipple_frontend::{
             format::{format_type, Format, TypeFunctionFormat},
             SyntaxDecl, TraitDecl, Type, TypeDecl, TypeDeclKind,
         },
-        Expression, ExpressionKind, Program, Span,
+        Expression, ExpressionKind, Program, Span, TypeKind,
     },
     diagnostics::DiagnosticLevel,
     helpers::InternedString,
@@ -244,7 +244,7 @@ impl LanguageServer for Backend {
             if matches!(
                 expr.kind,
                 ExpressionKind::Variable(_) | ExpressionKind::Constant(_)
-            ) && matches!(expr.ty, Type::Function(_, _))
+            ) && matches!(expr.ty.kind, TypeKind::Function(_, _))
             {
                 semantic_tokens.push((expr.span, SemanticTokenType::FUNCTION));
             }

--- a/website/shared/wasm/src/lib.rs
+++ b/website/shared/wasm/src/lib.rs
@@ -601,8 +601,10 @@ fn get_syntax_highlighting(
             expr.kind,
             wipple_frontend::analysis::ExpressionKind::Variable(_)
                 | wipple_frontend::analysis::ExpressionKind::Constant(_)
-        ) && matches!(expr.ty, wipple_frontend::analysis::Type::Function(_, _))
-        {
+        ) && matches!(
+            expr.ty.kind,
+            wipple_frontend::analysis::TypeKind::Function(_, _)
+        ) {
             items.push(AnalysisOutputSyntaxHighlightingItem {
                 start: expr.span.original().primary_start(),
                 end: expr.span.original().primary_end(),
@@ -693,8 +695,11 @@ fn get_completions(program: &wipple_frontend::analysis::Program) -> AnalysisOutp
 
     for decl in program.declarations.constants.values() {
         let completion = Completion {
-            kind: matches!(decl.ty, wipple_frontend::analysis::Type::Function(_, _))
-                .then_some("function"),
+            kind: matches!(
+                decl.ty.kind,
+                wipple_frontend::analysis::TypeKind::Function(_, _)
+            )
+            .then_some("function"),
             name: decl.name.to_string(),
             help: decl.attributes.decl_attributes.help.iter().join("\n"),
             template: decl
@@ -732,8 +737,11 @@ fn get_completions(program: &wipple_frontend::analysis::Program) -> AnalysisOutp
         };
 
         variables.push(Completion {
-            kind: matches!(decl.ty, wipple_frontend::analysis::Type::Function(_, _))
-                .then_some("function"),
+            kind: matches!(
+                decl.ty.kind,
+                wipple_frontend::analysis::TypeKind::Function(_, _)
+            )
+            .then_some("function"),
             name: name.clone(),
             help: String::new(),
             template: name,
@@ -1270,7 +1278,10 @@ pub fn hover(start: usize, end: usize) -> JsValue {
                 ..Default::default()
             };
 
-            let is_function = matches!(decl.ty, wipple_frontend::analysis::Type::Function(_, _));
+            let is_function = matches!(
+                decl.ty.kind,
+                wipple_frontend::analysis::TypeKind::Function(_, _)
+            );
 
             hovers.push((
                 span.original(),


### PR DESCRIPTION
Now the typechecker tracks the spans of the expressions from which types are determined, and uses them to power `[help-show-code]` — if this attribute is provided, any custom error messages referring to type parameters will instead show the code from which the type of the type parameter was determined.

For example, `+` uses `[help-show-code]` to make it easier to see which expressions were parsed as part of the addition:

```
error: cannot add `show 1` to `2`
   ┌─ test.wpl:1:8
   │
 1 │ show 1 + 2
   │ ------ ^ - this has type `Number`
   │ │      │
   │ │      could not find instance `Add () Number _`
   │ │      `+` consumes all expressions on either side; you may be missing parentheses
   │ this has type `()`
   │ this is parsed as one single input to `+`
   │
   ┌─ std/math.wpl:17:14
   │
17 │   'a + 'b -> Add 'b 'a
   │              --- actual error occurred here
   │
   = for more information, see https://wipple.dev/playground/?lesson=errors/missing-instance
```