### PR TITLE
Only swap expected and actual output types for the function being called

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,4 +30,4 @@ jobs:
             - uses: codecov/codecov-action@v4.0.1
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
-                  files: ./coverage/coverage.xml
+                  files: coverage/cobertura.xml

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,4 @@
 {
-    "files.exclude": {
-        "coverage": true
-    },
     "coverage-gutters.coverageFileNames": ["coverage/lcov.info"],
     "wipple.interface": ".wipple/base.wippleinterface",
     "wipple.libraries": [".wipple/base.wipplelibrary"]

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -30,7 +30,7 @@ tasks:
                     cargo install grcov --force
                 fi
             - rm -rf coverage && mkdir -p coverage
-            - grcov . --binary-path target/debug/ -s . -t cobertura --branch --ignore-not-existing --ignore \"/*\" -o coverage/coverage.xml
+            - grcov . --binary-path target/debug/ -s . -t cobertura,html --branch --ignore-not-existing --keep-only 'compiler/**/*' --keep-only 'interpreter/**/*' --keep-only 'render/**/*' -o coverage
 
     # doctest:
     #     run: once

--- a/compiler/typecheck/src/resolve.rs
+++ b/compiler/typecheck/src/resolve.rs
@@ -4950,14 +4950,17 @@ fn refine_mismatch_error<D: Driver>(
                             .type_context
                             .tracked_expression(actual_parent_expression_id);
 
-                        if let ExpressionKind::Call { .. } = &actual_parent_expression.item.kind {
-                            let actual_output = actual_output.as_ref().clone();
-                            let expected_output = expected_output.as_ref().clone();
+                        if let ExpressionKind::Call { function, .. } =
+                            &actual_parent_expression.item.kind
+                        {
+                            if function.info == actual.info {
+                                let actual_output = actual_output.as_ref().clone();
+                                let expected_output = expected_output.as_ref().clone();
 
-                            // A function's output type is contravariant, so swap the order
-                            *info = actual_parent_expression.info.clone();
-                            *expected = actual_output;
-                            *actual = expected_output;
+                                *info = actual_parent_expression.info.clone();
+                                *expected = actual_output;
+                                *actual = expected_output;
+                            }
                         }
                     }
                 }

--- a/test/snapshots/wipple_test__mismatched-higher-order-function.test.wipple.snap
+++ b/test/snapshots/wipple_test__mismatched-higher-order-function.test.wipple.snap
@@ -1,0 +1,8 @@
+---
+source: test/src/lib.rs
+expression: snapshot
+---
+diagnostics:
+  - "tests/mismatched-higher-order-function.test.wipple:10:3: error: expected `Text -> Text` here, but found `Text -> Number`"
+  - "tests/mismatched-higher-order-function.test.wipple:12:20: error: expected a piece of text here, but found a number"
+output: []

--- a/test/tests/mismatched-higher-order-function.test.wipple
+++ b/test/tests/mismatched-higher-order-function.test.wipple
@@ -1,0 +1,13 @@
+-- [should error]
+
+x :: Text -> Number
+x : ...
+
+y :: (Text -> Text) -> Unit
+y : ...
+
+-- The error message should appear on `x` here
+y x
+
+z : (_ :: Text) -> 42 -- The error message should appear on `42` here
+y z


### PR DESCRIPTION
This prevents incorrect diagnostics on higher-order functions.