### PR TITLE
Fix `web:playground:serve` not running code

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -176,6 +176,7 @@ tasks:
             - web:playground:bundle
         dir: web/playground
         cmds:
+            - ./wasm/build.sh
             - npm run dev
 
     web:playground:build:

--- a/web/playground/vite.config.ts
+++ b/web/playground/vite.config.ts
@@ -6,7 +6,7 @@ import svgr from "vite-plugin-svgr";
 import topLevelAwait from "vite-plugin-top-level-await";
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig((env) => ({
     base: "/playground",
     plugins: [react(), lezer(), svgr(), topLevelAwait()],
     build: {
@@ -35,4 +35,7 @@ export default defineConfig({
             "Cross-Origin-Embedder-Policy": "require-corp",
         },
     },
-});
+    define: {
+        __DEV__: env.mode === "development",
+    },
+}));

--- a/web/playground/wasm/src/util/is_dev.rs
+++ b/web/playground/wasm/src/util/is_dev.rs
@@ -1,0 +1,9 @@
+use crate::util::OrThrowExt;
+use web_sys::js_sys;
+
+pub fn is_dev() -> bool {
+    js_sys::eval("typeof __DEV__ !== 'undefined' && __DEV__ === true")
+        .or_throw("failed to get __DEV__")
+        .as_bool()
+        .or_throw("__DEV__ is not a boolean")
+}

--- a/web/playground/wasm/src/util/mod.rs
+++ b/web/playground/wasm/src/util/mod.rs
@@ -1,5 +1,9 @@
+mod is_dev;
+mod or_throw;
 mod send_wrapper;
 mod variadic_function;
 
+pub use is_dev::*;
+pub use or_throw::*;
 pub use send_wrapper::*;
 pub use variadic_function::*;

--- a/web/playground/wasm/src/util/or_throw.rs
+++ b/web/playground/wasm/src/util/or_throw.rs
@@ -1,0 +1,50 @@
+pub trait OrThrowExt {
+    type Result;
+
+    fn or_throw(self, msg: &str) -> Self::Result;
+    fn or_warn(self, msg: &str);
+}
+
+impl<T, E: std::fmt::Debug> OrThrowExt for Result<T, E> {
+    type Result = T;
+
+    #[track_caller]
+    fn or_throw(self, msg: &str) -> T {
+        let location = std::panic::Location::caller();
+
+        self.unwrap_or_else(|err| {
+            wasm_bindgen::throw_str(&format!("{}: {}: {:?}", location, msg, err));
+        })
+    }
+
+    #[track_caller]
+    fn or_warn(self, msg: &str) {
+        let location = std::panic::Location::caller();
+
+        if let Err(err) = self {
+            web_sys::console::warn_1(&format!("{}: {}: {:?}", location, msg, err).into());
+        }
+    }
+}
+
+impl<T> OrThrowExt for Option<T> {
+    type Result = T;
+
+    #[track_caller]
+    fn or_throw(self, msg: &str) -> T {
+        let location = std::panic::Location::caller();
+
+        self.unwrap_or_else(|| {
+            wasm_bindgen::throw_str(&format!("{}: {}", location, msg));
+        })
+    }
+
+    #[track_caller]
+    fn or_warn(self, msg: &str) {
+        let location = std::panic::Location::caller();
+
+        if self.is_none() {
+            web_sys::console::warn_1(&format!("{}: {}", location, msg).into());
+        }
+    }
+}


### PR DESCRIPTION
In production, we have to rewrite the path to the `wasm_thread_entry_point` to a custom `worker_entrypoint.js` file in order to spawn threads and run the playground code, but this isn't necessary during development. This PR only rewrites the path in production.