### PR TITLE
Improve diagnostics for missing closing delimiters

### DIFF
--- a/test/snapshots/wipple_test__missing-closing-parenthesis.test.wipple.snap
+++ b/test/snapshots/wipple_test__missing-closing-parenthesis.test.wipple.snap
@@ -1,0 +1,5 @@
+---
+source: test/src/lib.rs
+expression: snapshot
+---
+tests/missing-closing-parenthesis.test.wipple:3:11: error: expected a closing parenthesis (`)`) here

--- a/test/tests/missing-closing-parenthesis.test.wipple
+++ b/test/tests/missing-closing-parenthesis.test.wipple
@@ -1,0 +1,3 @@
+-- [should error]
+
+show (1 + 2


### PR DESCRIPTION
This program is missing a closing parenthesis:

```wipple
show (1 + 2
```

Before, the diagnostic would be:

```
error
 --> Wipple/test.wipple:1:6
  |
1 | show (1 + 2
  |      ^ expected top level here
  |
```

Now, it is much more informative:

```
error
 --> Wipple/test.wipple:1:11
  |
1 | show (1 + 2
  |           ^ expected a closing parenthesis (`)`) here
  |
```