### PR TITLE
Don't display 'UnresolvedInstance' errors when all the types are unknown

### DIFF
--- a/compiler/typecheck/src/infer/errors.rs
+++ b/compiler/typecheck/src/infer/errors.rs
@@ -1,9 +1,9 @@
 use crate::{
     infer::{
-        r#trait::{refine_mismatch_error, resolve_trait},
+        r#trait::resolve_trait,
         r#type::{finalize_instance, finalize_type, finalize_type_reason},
-        types::{context::TypeContext, Instance, Type},
-        FinalizeContext, FormattedText, ResolveContext,
+        types::{context::TypeContext, unify::unify, Instance, Type, TypeKind},
+        ExpressionKind, FinalizeContext, FormattedText, ResolveContext,
     },
     Driver,
 };
@@ -319,4 +319,171 @@ pub fn try_report_custom_unused_error<D: Driver>(
     }
 
     false
+}
+
+pub fn refine_mismatch_error<D: Driver>(
+    info: &mut D::Info,
+    actual: &mut Type<D>,
+    expected: &mut Type<D>,
+    finalize_context: &mut FinalizeContext<'_, D>,
+) {
+    actual.apply_in_context_mut(finalize_context.type_context);
+    expected.apply_in_context_mut(finalize_context.type_context);
+
+    loop {
+        let prev_actual = actual.clone();
+        let prev_expected = expected.clone();
+
+        // Highlight the last statement in a 'do' block instead of the entire block
+        if let Some(actual_expression_id) = actual.expression {
+            let actual_expression = finalize_context
+                .type_context
+                .tracked_expression(actual_expression_id);
+
+            if let ExpressionKind::Do(block_expression) = &actual_expression.item.kind {
+                if let ExpressionKind::Block { statements, .. } = &block_expression.item.kind {
+                    if let Some(last_statement) = statements.last() {
+                        *info = last_statement.info.clone();
+                        *actual = last_statement.item.r#type.clone();
+                    }
+                }
+            }
+        }
+
+        // Highlight the call expression instead of the function if the output
+        // is mismatched
+        if let TypeKind::Function {
+            inputs: actual_inputs,
+            output: actual_output,
+        } = &actual.kind
+        {
+            if let TypeKind::Function {
+                inputs: expected_inputs,
+                output: expected_output,
+            } = &expected.kind
+            {
+                if actual_inputs.len() == expected_inputs.len()
+                    && actual_inputs
+                        .iter()
+                        .zip(expected_inputs)
+                        .all(|(actual, expected)| {
+                            unify(
+                                finalize_context.driver,
+                                actual,
+                                expected,
+                                finalize_context.type_context,
+                            )
+                        })
+                {
+                    if let Some(actual_parent_expression_id) = actual.parent_expression {
+                        let actual_parent_expression = finalize_context
+                            .type_context
+                            .tracked_expression(actual_parent_expression_id);
+
+                        if let ExpressionKind::Call { function, .. } =
+                            &actual_parent_expression.item.kind
+                        {
+                            if function.info == actual.info {
+                                let actual_output = actual_output.as_ref().clone();
+                                let expected_output = expected_output.as_ref().clone();
+
+                                *info = actual_parent_expression.info.clone();
+                                *expected = actual_output;
+                                *actual = expected_output;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Track down the source of a mismatched function output
+        if let TypeKind::Function {
+            inputs: actual_inputs,
+            output: actual_output,
+        } = &actual.kind
+        {
+            if let TypeKind::Function {
+                inputs: expected_inputs,
+                output: expected_output,
+            } = &expected.kind
+            {
+                if actual_inputs.len() == expected_inputs.len()
+                    && actual_inputs
+                        .iter()
+                        .zip(expected_inputs)
+                        .all(|(actual, expected)| {
+                            unify(
+                                finalize_context.driver,
+                                actual,
+                                expected,
+                                finalize_context.type_context,
+                            )
+                        })
+                    && !unify(
+                        finalize_context.driver,
+                        actual_output,
+                        expected_output,
+                        finalize_context.type_context,
+                    )
+                {
+                    if let Some(actual_expression_id) = actual.expression {
+                        let actual_expression = finalize_context
+                            .type_context
+                            .tracked_expression(actual_expression_id);
+
+                        // Don't look inside constants/traits/etc. to refine the
+                        // error message
+                        if !actual_expression.item.kind.is_reference() {
+                            *info = actual_output.info.clone();
+                            *actual = actual_output.as_ref().clone();
+                            *expected = expected_output.as_ref().clone();
+                        }
+                    }
+                }
+            }
+        }
+
+        // TODO: If the error involves `A = B` on both sides, replace it with
+        // "expected `A` but found `B`"
+
+        if prev_actual == *actual && prev_expected == *expected {
+            break;
+        }
+    }
+}
+
+pub fn refine_unknown_type_for_error<D: Driver>(
+    r#type: &Type<D>,
+    finalize_context: &mut FinalizeContext<'_, D>,
+) -> Option<D::Info> {
+    let r#type = r#type.apply_in_context(finalize_context.type_context);
+
+    loop {
+        let prev_type = r#type.clone();
+
+        // Highlight the call expression instead of the function if the output
+        // is unknown
+        if let TypeKind::Function { output, .. } = &r#type.kind {
+            if output.is_currently_unknown() {
+                if let Some(parent_expression_id) = r#type.parent_expression {
+                    let parent_expression = finalize_context
+                        .type_context
+                        .tracked_expression(parent_expression_id);
+
+                    if let ExpressionKind::Call { function, .. } = &parent_expression.item.kind {
+                        if function.info == r#type.info {
+                            return Some(parent_expression.info.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        if prev_type == r#type {
+            break;
+        }
+    }
+
+    None
 }

--- a/compiler/typecheck/src/infer/mod.rs
+++ b/compiler/typecheck/src/infer/mod.rs
@@ -6,19 +6,15 @@ pub mod r#trait;
 pub mod r#type;
 pub mod types;
 
-use crate::infer::{
-    errors::QueuedError,
-    types::{Type, TypeVariable},
-};
 use crate::{
     infer::{
-        errors::report_queued_errors,
+        errors::{report_queued_errors, QueuedError},
         expression::{
             finalize_expression, infer_expression, resolve_expression,
             substitute_defaults_in_expression,
         },
         r#type::{infer_instance, infer_type},
-        types::{context::TypeContext, unify::try_unify_expression, Instance},
+        types::{context::TypeContext, unify::try_unify_expression, Instance, Type, TypeVariable},
     },
     Driver,
 };

--- a/compiler/typecheck/src/infer/types/mod.rs
+++ b/compiler/typecheck/src/infer/types/mod.rs
@@ -45,6 +45,13 @@ impl<D: Driver> Type<D> {
         self
     }
 
+    pub fn is_currently_unknown(&self) -> bool {
+        matches!(
+            self.kind,
+            TypeKind::Variable(_) | TypeKind::Opaque(_) | TypeKind::Unknown
+        )
+    }
+
     pub fn contains_variable(&self, variable: &TypeVariable<D>) -> bool {
         match &self.kind {
             TypeKind::Variable(var) => var.counter == variable.counter,

--- a/test/snapshots/wipple_test__bounds-dont-influence-other-bounds.test.wipple.snap
+++ b/test/snapshots/wipple_test__bounds-dont-influence-other-bounds.test.wipple.snap
@@ -2,4 +2,4 @@
 source: test/src/lib.rs
 expression: snapshot
 ---
-tests/bounds-dont-influence-other-bounds.test.wipple:12:1: error: `(f :: (Number ; _))` requires `T _`
+tests/bounds-dont-influence-other-bounds.test.wipple:12:1: error: this code produces `Number ; _`, but the `_`s are unknown

--- a/test/snapshots/wipple_test__unknown-type-with-bounds.test.wipple.snap
+++ b/test/snapshots/wipple_test__unknown-type-with-bounds.test.wipple.snap
@@ -1,0 +1,5 @@
+---
+source: test/src/lib.rs
+expression: snapshot
+---
+tests/unknown-type-with-bounds.test.wipple:8:1: error: could not determine what kind of value this code produces

--- a/test/tests/unknown-type-with-bounds.test.wipple
+++ b/test/tests/unknown-type-with-bounds.test.wipple
@@ -1,0 +1,8 @@
+-- [should error]
+
+T : Value => trait Value
+
+x :: Value where (T Value) => Value
+x : T
+
+x -- error: unknown type, NOT error: requires `T _`


### PR DESCRIPTION
Previously:

```
error
 --> playground:1:8
  |
1 | name : prompt "What is your name?"
  |        ^^^^^^ `prompt` requires `Read _`
  |
```

Now:

```
error
 --> playground:1:8
  |
1 | name : prompt "What is your name?"
  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ could not determine what kind of value this code produces
  |
```