### PR TITLE
Display comments in UI font

### DIFF
--- a/web/playground/src/index.css
+++ b/web/playground/src/index.css
@@ -179,6 +179,10 @@ code,
     }
 }
 
+.tok-comment {
+    @apply ui-font;
+}
+
 /* Piano */
 
 .piano-preview .ReactPiano__Keyboard {


### PR DESCRIPTION
Now comments are rendered like this:

<img src="https://github.com/user-attachments/assets/eff91b37-10da-4211-91ce-5996ab8f25a7" width="400">